### PR TITLE
build: add target for cleaning compiler images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ git:
 notifications:
   email: false
 
+before_install:
+  - go mod download
+
 script:
   - make check  
   - go test -race -coverprofile=coverage.txt -covermode=atomic ./...

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,3 +1,7 @@
+# This image is used when compiling (see Makefile)
+# It is created from a Go image, and added dependencies for caching
+
+# GO_IMAGE environment can be set to override base image
 ARG GO_IMAGE=golang:1.12.7
 
 FROM $GO_IMAGE AS build

--- a/docs/building.md
+++ b/docs/building.md
@@ -33,14 +33,18 @@ $ git remote add origin git@github.com:<YOUR-USER>/kheer.git
 
 ## Make targets
 
+_User facing_ targets are
+
 - `clean`
 
     Deletes `./_output` folder.
 
-- `build`
+- `all` or `build`
 
-    Is the default taget. It compiles an amd64 binary for your current OS.
+    Is the default target. It compiles an amd64 binary for your current OS.
     Computer architecture and OS can be set using `OS` and `ARCH` environment variables. A docker Go image is used for compiling, and the result is stored at `./_output`.
+
+    Compilation process creates a docker image (`COMPILER_IMAGE` at Makefile) that includes all dependencies for caching.
 
 - `build-all`
 
@@ -49,3 +53,9 @@ $ git remote add origin git@github.com:<YOUR-USER>/kheer.git
 - `check`
 
     Perfoms unit tests, race detection, vet, and format checks.
+
+- `clean-compiler-images`
+
+    Builds generate a Go based image that includes cached dependencies. Compiling cached images can be removed using this target. This might come handy when changing the `GO_IMAGE` tag when using a new Go version, to delete existing images that will no longer be used.
+
+    If the image is deleted, a new one will be generated at the next build.


### PR DESCRIPTION
Create `clean-compiler-images` for cleaning cached images